### PR TITLE
mkdir needs no params

### DIFF
--- a/rc/tug.kak
+++ b/rc/tug.kak
@@ -84,7 +84,7 @@ define-command cp -params 1 -file-completion -docstring %{
   }
 }
 
-define-command mkdir -params 1 -file-completion -docstring %{
+define-command mkdir -docstring %{
   Make directories for the current buffer
 } %{
   evaluate-commands %sh{


### PR DESCRIPTION
I assume `mkdir` command needs no `-params 1` and `-file-completion`.